### PR TITLE
build: remove unwanted packages from installer

### DIFF
--- a/install/apps/xtras.sh
+++ b/install/apps/xtras.sh
@@ -3,17 +3,7 @@
 if [ -z "$OMARCHY_BARE" ]; then
   yay -S --noconfirm --needed \
     gnome-calculator gnome-keyring signal-desktop \
-    obsidian-bin libreoffice obs-studio kdenlive \
-    xournalpp localsend-bin
-
-  # Packages known to be flaky or having key signing issues are run one-by-one
-  for pkg in pinta typora spotify zoom; do
-    yay -S --noconfirm --needed "$pkg" ||
-      echo -e "\e[31mFailed to install $pkg. Continuing without!\e[0m"
-  done
-
-  yay -S --noconfirm --needed 1password-beta 1password-cli ||
-    echo -e "\e[31mFailed to install 1password. Continuing without!\e[0m"
+    localsend-bin
 fi
 
 # Copy over Omarchy applications

--- a/install/development/development.sh
+++ b/install/development/development.sh
@@ -4,5 +4,4 @@ yay -S --noconfirm --needed \
   cargo clang llvm mise \
   imagemagick \
   mariadb-libs postgresql-libs \
-  github-cli \
   lazygit lazydocker-bin


### PR DESCRIPTION
Removes the following packages from the installation scripts:
- 1password-beta
- 1password-cli
- github-cli
- kdenlive
- obs-studio
- obsidian
- pinta
- libreoffice-fresh
- spotify
- typora
- xournalpp
- zoom